### PR TITLE
fix: expand ROUTER_PORT env var in router Dockerfile CMD

### DIFF
--- a/container-orch/router/Dockerfile
+++ b/container-orch/router/Dockerfile
@@ -15,4 +15,4 @@ EXPOSE 18888
 ENV ROUTER_PORT=18888 \
     TENANTS_FILE=/app/tenants.json
 
-CMD ["python", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "18888"]
+CMD ["sh", "-c", "python -m uvicorn main:app --host 0.0.0.0 --port ${ROUTER_PORT:-18888}"]


### PR DESCRIPTION
Closes #2

Use `sh -c` wrapper in the CMD instruction so `${ROUTER_PORT:-18888}` is evaluated at container start instead of baking the port number into the exec-form argument. The default of 18888 is preserved via the `:-` fallback.

Generated with [Claude Code](https://claude.ai/code)